### PR TITLE
Extend Documentation With Transaction Amount Restrictions

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -382,6 +382,8 @@ If `null`, terminal settings will be used.
 
 When `ForceCustomTip` proprietary tag is set to `true`, the terminal will force entering the tip manually, even if the smart tips are enabled.
 
+Amounts specified in the `AmountsReq` object must have a maximum of **7 integer digits** and **2 fraction digits**.
+
 + Request (application/json)
 
     + Headers


### PR DESCRIPTION
The documentation now includes transaction amount restrictions (integer and fraction limits).